### PR TITLE
mark all required fields non-nullable

### DIFF
--- a/src/main/kotlin/three/consulting/epoc/dto/EmployeeDTO.kt
+++ b/src/main/kotlin/three/consulting/epoc/dto/EmployeeDTO.kt
@@ -3,12 +3,13 @@ package three.consulting.epoc.dto
 import three.consulting.epoc.entity.Employee
 import java.time.LocalDate
 import java.time.LocalDateTime
+import javax.validation.constraints.NotBlank
 
 data class EmployeeDTO(
     val id: Long? = null,
-    val first_name: String,
-    val last_name: String,
-    val email: String,
+    @field:NotBlank val first_name: String,
+    @field:NotBlank val last_name: String,
+    @field:NotBlank val email: String,
     val start_date: LocalDate? = null,
     val created: LocalDateTime? = null,
     val updated: LocalDateTime? = null

--- a/src/main/kotlin/three/consulting/epoc/dto/ProjectDTO.kt
+++ b/src/main/kotlin/three/consulting/epoc/dto/ProjectDTO.kt
@@ -5,15 +5,16 @@ import three.consulting.epoc.entity.Project
 import java.time.LocalDate
 import java.time.LocalDateTime
 import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
 
 data class ProjectDTO(
     val id: Long? = null,
     @field:NotBlank val name: String,
     val description: String? = null,
-    val startDate: LocalDate,
+    @field:NotNull val startDate: LocalDate,
     val endDate: LocalDate? = null,
-    val customer: CustomerDTO,
-    val managingEmployee: EmployeeDTO,
+    @field:NotNull val customer: CustomerDTO,
+    @field:NotNull val managingEmployee: EmployeeDTO,
     val status: Status = Status.ACTIVE,
     val created: LocalDateTime? = null,
     val updated: LocalDateTime? = null,

--- a/src/main/kotlin/three/consulting/epoc/dto/TaskDTO.kt
+++ b/src/main/kotlin/three/consulting/epoc/dto/TaskDTO.kt
@@ -4,12 +4,13 @@ import three.consulting.epoc.common.Status
 import three.consulting.epoc.entity.Task
 import java.time.LocalDateTime
 import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
 
 data class TaskDTO(
     val id: Long? = null,
     @field:NotBlank val name: String,
     val description: String? = null,
-    val project: ProjectDTO,
+    @field:NotNull val project: ProjectDTO,
     val created: LocalDateTime? = null,
     val updated: LocalDateTime? = null,
     val status: Status = Status.ACTIVE,

--- a/src/main/kotlin/three/consulting/epoc/dto/TimesheetDTO.kt
+++ b/src/main/kotlin/three/consulting/epoc/dto/TimesheetDTO.kt
@@ -6,14 +6,15 @@ import java.time.LocalDateTime
 import javax.validation.constraints.Max
 import javax.validation.constraints.Min
 import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
 
 data class TimesheetDTO(
     val id: Long? = null,
     @field:NotBlank val name: String,
     val description: String? = null,
     @field:Min(0) @field:Max(100) val allocation: Int,
-    val project: ProjectDTO,
-    val employee: EmployeeDTO,
+    @field:NotNull val project: ProjectDTO,
+    @field:NotNull val employee: EmployeeDTO,
     val created: LocalDateTime? = null,
     val updated: LocalDateTime? = null,
     val status: Status = Status.ACTIVE,

--- a/src/main/kotlin/three/consulting/epoc/dto/TimesheetEntryDTO.kt
+++ b/src/main/kotlin/three/consulting/epoc/dto/TimesheetEntryDTO.kt
@@ -11,9 +11,9 @@ data class TimesheetEntryDTO(
     @field:NotNull val quantity: Duration,
     @field:NotNull val date: LocalDate,
     val description: String? = null,
-    val timesheet: TimesheetDTO,
-    val timeCategory: TimeCategoryDTO,
-    val task: TaskDTO,
+    @field:NotNull val timesheet: TimesheetDTO,
+    @field:NotNull val timeCategory: TimeCategoryDTO,
+    @field:NotNull val task: TaskDTO,
     val created: LocalDateTime? = null,
     val updated: LocalDateTime? = null,
 ) {


### PR DESCRIPTION
Some required fields are marked nullable in the OpenAPI docs. This results to [incorrect types](https://github.com/three-consulting/epoc-frontend/blob/main/lib/types/api.ts#L90-L101) in the frontend. This makes the types much less useful, since typescript can't catch attempts where the developer attempts to make an API call with some requried fields missing.