### PR TITLE
Set max Java heap size to be 50% of container RAM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ EXPOSE 8080
 
 USER user
 
-ENTRYPOINT ["java", "-XX:+ExitOnOutOfMemoryError", "-Xms128m", "-Xmx128m", "-jar", "/epoc.jar"]
+ENTRYPOINT ["java", "-XX:+ExitOnOutOfMemoryError", "-Xms128m", "-Xmx256m", "-jar", "/epoc.jar"]


### PR DESCRIPTION
We're using a hobby dyno: https://www.heroku.com/dynos
How to set jvm max heap with respect to container memory https://www.eclipse.org/openj9/docs/xxusecontainersupport/