### PR TITLE
standalone dockerfile

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Run tests
         run: |
-          ./gradlew clean test assemble
+          ./gradlew clean test
 
       - name: Build, Push and Release a Docker container to Heroku.
         uses: gonuit/heroku-docker-deploy@v1.3.3

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Run tests
       run: |
-        ./gradlew clean test assemble
+        ./gradlew clean test
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,21 +14,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Setup Java
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'adopt'
-          architecture: x64
-
-      - name: Grant execute permission for gradlew
-        run: |
-          chmod +x gradlew
-
-      - name: Assemble jar
-        run: |
-          ./gradlew clean assemble
-
       - name: Build, Push and Release a Docker container to Heroku.
         uses: gonuit/heroku-docker-deploy@v1.3.3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM gradle:jdk17 as builder
 WORKDIR /builder
 COPY . .
 # build jar
-RUN gradle bootJar
+RUN gradle clean bootJar
 # extract layers from built jar
 RUN java -Djarmode=layertools -jar build/libs/epoc.jar extract --destination layers
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,25 @@
+FROM gradle:jdk17 as builder
+
+WORKDIR /builder
+COPY . .
+# build jar
+RUN gradle bootJar
+# extract layers from built jar
+RUN java -Djarmode=layertools -jar build/libs/epoc.jar extract --destination layers
+
 FROM azul/zulu-openjdk-alpine:17-jre
 
 RUN adduser -u 1999 -D user
 
-COPY build/libs/epoc.jar /epoc.jar
+WORKDIR /app
+# copy extracted layers from builder
+COPY --from=builder /builder/layers/dependencies ./
+COPY --from=builder /builder/layers/spring-boot-loader ./
+COPY --from=builder /builder/layers/snapshot-dependencies ./
+COPY --from=builder /builder/layers/application ./
 
 EXPOSE 8080
 
 USER user
 
-ENTRYPOINT ["java", "-XX:+ExitOnOutOfMemoryError", "-Xms128m", "-Xmx256m", "-jar", "/epoc.jar"]
+ENTRYPOINT ["java", "-XX:+ExitOnOutOfMemoryError", "-Xms128m", "-Xmx256m", "org.springframework.boot.loader.JarLauncher"]


### PR DESCRIPTION
Old build was more made for pushing the images into a registry explicity, but now that's done while deploying to heroku. Now we have a Dockerfile that doesn't need any previously run `gradle assemble`. 

Extracting the layered jar for optimization https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/#packaging-layered-jars