### PR TITLE
Update run instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ gpg --batch --yes --symmetric --passphrase $(gopass show 3/epoc/GPG) --cipher-al
 ```
 
 ### Run app
-On IDEA create new gradle configuration and use `bootRun` as the run argument with env variables
+On IDEA [create new gradle configuration](https://www.jetbrains.com/help/idea/run-debug-gradle.html) and use `bootRun` as the run argument with env variables
 
 | variable                   | value                            |
 |----------------------------|----------------------------------|
@@ -33,7 +33,7 @@ On IDEA create new gradle configuration and use `bootRun` as the run argument wi
 | SPRING_DATASOURCE_PASSWORD | password                         |
 | SPRING_DATASOURCE_URL      | jdbc:postgresql://localhost/epoc |
 
-To run the application with security enabled add the following envs
+To run the application with security enabled add the following envs, which can also be found in [shared secrets](https://github.com/three-consulting/secrets) under `edam/epoc/auth/`
 
 | variable                                              | value                                                                                     |
 |-------------------------------------------------------|-------------------------------------------------------------------------------------------|
@@ -41,14 +41,15 @@ To run the application with security enabled add the following envs
 | SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER-URI  | https://securetoken.google.com/<firebase-app-name>                                        |
 | SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK-SET-URI | https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com |
 
-To run the application enabled use the following env
+To run the application without spring security enabled use the following env
 
 | variable               | value |
 |------------------------|-------|
 | SPRING_PROFILES_ACTIVE | dev   |
 
+Once running locally, the api docs can be found at `localhost:8080/docs-ui.html`
 
-
+## Run a database
 Run a postgres db in a container
 ```bash
 docker run --rm --name postgres -e POSTGRES_USER=user -e POSTGRES_PASSWORD=password -e POSTGRES_DB=epoc -p 5432:5432 postgres:14-alpine
@@ -60,6 +61,5 @@ docker run --rm --name epoc-db -e POSTGRES_USER=user -e POSTGRES_PASSWORD=passwo
 ```
 
 ## Run tests
-This app uses flyway for migrations, so JPA Buddy plugin for Intellij IDEA is a tool that can be used to create migration files.
 The tests use [this embedded database](https://github.com/zonkyio/embedded-database-spring-test), which is essentially a wrapper for testcontainers, so docker is needed on host machine when running tests.
 Run tests with `gradle :clean :test` or create a new gradle run configuration on IDEA and use `clean test` as run command.

--- a/README.md
+++ b/README.md
@@ -27,24 +27,36 @@ gpg --batch --yes --symmetric --passphrase $(gopass show 3/epoc/GPG) --cipher-al
 ### Run app
 On IDEA create new gradle configuration and use `bootRun` as the run argument with env variables
 
+| variable                   | value                            |
+|----------------------------|----------------------------------|
+| SPRING_DATASOURCE_USERNAME | user                             |
+| SPRING_DATASOURCE_PASSWORD | password                         |
+| SPRING_DATASOURCE_URL      | jdbc:postgresql://localhost/epoc |
+
+To run the application with security enabled add the following envs
+
 | variable                                              | value                                                                                     |
 |-------------------------------------------------------|-------------------------------------------------------------------------------------------|
-| SPRING_DATASOURCE_USERNAME                            | user                                                                                      |
-| SPRING_DATASOURCE_PASSWORD                            | password                                                                                  |
-| SPRING_DATASOURCE_URL                                 | jdbc:postgresql://localhost/epoc                                                          |
 | GOOGLE_APPLICATION_CREDENTIALS                        | firebase/epoc-auth-firebase-adminsdk.json                                                 |
 | SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER-URI  | https://securetoken.google.com/<firebase-app-name>                                        |
 | SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK-SET-URI | https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com |
+
+To run the application enabled use the following env
+
+| variable               | value |
+|------------------------|-------|
+| SPRING_PROFILES_ACTIVE | dev   |
+
+
 
 Run a postgres db in a container
 ```bash
 docker run --rm --name postgres -e POSTGRES_USER=user -e POSTGRES_PASSWORD=password -e POSTGRES_DB=epoc -p 5432:5432 postgres:14-alpine
 ```
 
-## Run locally without websecurity
-To run locally without securing requests use the environment variables from above except `SPRING_SECURITY_*` and on gradle run
+Run the db with seed data in a container
 ```bash
-bootRun --args='--spring.profiles.active=dev'
+docker run --rm --name epoc-db -e POSTGRES_USER=user -e POSTGRES_PASSWORD=password -e POSTGRES_DB=epoc -p 5432:5432 ghcr.io/three-consulting/epoc-db:latest
 ```
 
 ## Run tests


### PR DESCRIPTION
The run commands use environment variables, so I highly suggest creating gradle run configurations in intellij IDEA to be able to do this https://www.jetbrains.com/help/idea/run-debug-gradle.html you can add the variables once and save the config. Then it'll be available for you to use it in the future.

Try running the app locally by first starting the epoc-db container and then running the application without security enabled in IDEA. After both are up and running you should see that everything is working using curl, e.g.
```bash
$ curl localhost:8080/customer/1 | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   157    0   157    0     0  19625      0 --:--:-- --:--:-- --:--:-- 19625
{
   "created" : "2022-08-05T07:31:32.488224",
   "description" : "Get the pile",
   "enabled" : true,
   "id" : 1,
   "name" : "Maurin Makkara Oy",
   "updated" : "2022-08-05T07:31:32.488224"
}
```
Then you can try running the app with security enabled and verify that the above curl command responds with unauthorized.

The schema can be seen using either one: localhost:8080/docs-ui.html