### PR TITLE
fix: export csv timesheet entries will be sorted by date value

### DIFF
--- a/src/main/kotlin/three/consulting/epoc/service/TimesheetEntryService.kt
+++ b/src/main/kotlin/three/consulting/epoc/service/TimesheetEntryService.kt
@@ -47,7 +47,8 @@ class TimesheetEntryService(private val timesheetEntryRepository: TimesheetEntry
         }
 
         var columnNames = "hours;task;project;date;email\n"
-        val rows = entries.joinToString("") { entry -> "${entry.quantity};${entry.task.name};${entry.timesheet.project.name};${entry.date};${entry.timesheet.employee.email}\n" }
+        val sortedEntries = entries.sortedBy { it.date }
+        val rows = sortedEntries.joinToString("") { entry -> "${entry.quantity};${entry.task.name};${entry.timesheet.project.name};${entry.date};${entry.timesheet.employee.email}\n" }
         return columnNames + rows
     }
 

--- a/src/test/kotlin/three/consulting/epoc/service/TimesheetEntryServiceIntegrationTest.kt
+++ b/src/test/kotlin/three/consulting/epoc/service/TimesheetEntryServiceIntegrationTest.kt
@@ -322,4 +322,26 @@ class TimesheetEntryServiceIntegrationTest : IntegrationTest() {
         assertThat(csv.contains("7.5;test;test;2022-04-01;$email")).isTrue
         assertThat(csv.contains("7.5;test;test;2022-04-03;test@worker.fi")).isFalse
     }
+
+    @Test
+    fun `timesheet entries for csv export order exists`() {
+        val date = LocalDate.parse("2023-03-01")
+        val desc = "Testing timesheet entry5"
+        val entry = timesheetEntryService.findTimesheetEntryForId(5)
+        assertThat(entry?.description).isEqualTo(desc)
+        assertThat(entry?.date).isEqualTo(date)
+    }
+
+    @Test
+    fun `timesheet entries are sorted when exported to csv`() {
+        val startDate = LocalDate.parse("2023-03-01")
+        val endDate = LocalDate.parse("2023-03-03")
+        val email = "matti@worker.fi"
+
+        val csv = timesheetEntryService.exportToCsv(startDate, endDate, email)
+        val csvHeader = "hours;task;project;date;email\n"
+        val comparedCsv = csvHeader + listOf(1, 2, 3).joinToString("") { "7.5;test;test;2023-03-0$it;$email\n" }
+
+        assertThat(csv).isEqualTo(comparedCsv)
+    }
 }

--- a/src/test/resources/db/migration/afterMigrate.sql
+++ b/src/test/resources/db/migration/afterMigrate.sql
@@ -25,4 +25,7 @@ INSERT INTO timesheet_entry(timesheet_id, task_id, quantity, date, description, 
     (1, 1, 7.5, '2022-04-01', 'Testing timesheet entry', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
     (1, 1, 7.5, '2022-04-03', 'Testing timesheet entry2', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
     (2, 1, 7.5, '2022-04-01', 'Testing timesheet entry3', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-    (2, 1, 1, '2022-04-03', 'Testing timesheet entry4', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+    (2, 1, 1, '2022-04-03', 'Testing timesheet entry4', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (3, 1, 7.5, '2023-03-01', 'Testing timesheet entry5', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (3, 1, 7.5, '2023-03-03', 'Testing timesheet entry6', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    (3, 1, 7.5, '2023-03-02', 'Testing timesheet entry7', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);


### PR DESCRIPTION
- Comparator for sorting dates in exportToCsv method
- Tests