### PR TITLE
Revoke user sessions on firebase update

### DIFF
--- a/src/main/kotlin/three/consulting/epoc/service/FirebaseService.kt
+++ b/src/main/kotlin/three/consulting/epoc/service/FirebaseService.kt
@@ -55,6 +55,7 @@ class FirebaseService(
             val employee = employeeRepository.findByFirebaseUid(employeeDTO.firebaseUid)
             if (employee != null) {
                 firebaseAuth.setCustomUserClaims(employeeDTO.firebaseUid, customClaims)
+                firebaseAuth.revokeRefreshTokens(employeeDTO.firebaseUid)
                 val updatedEmployee = Employee(employeeDTO)
                 return EmployeeDTO(employeeRepository.save(updatedEmployee))
             } else {


### PR DESCRIPTION
This should force user to authenticate again after their claims have changed.